### PR TITLE
Handle blpop/brpop timing out before a value is available.

### DIFF
--- a/modules/celtuce-core/src/celtuce/impl/cluster.clj
+++ b/modules/celtuce-core/src/celtuce/impl/cluster.clj
@@ -193,10 +193,12 @@
   ListCommands
   (blpop [this ^long sec ks]
     (let [res (.blpop this sec ^objects (into-array Object ks))]
-      [(.key res) (.value res)]))
+      (when res
+        [(.key res) (.value res)])))
   (brpop [this ^long sec ks]
     (let [res (.brpop this sec ^objects (into-array Object ks))]
-      [(.key res) (.value res)]))
+      (when res
+        [(.key res) (.value res)])))
   (brpoplpush [this ^long sec s d]
     (.brpoplpush this sec s d))
   (lindex [this k ^long idx]

--- a/modules/celtuce-core/src/celtuce/impl/server.clj
+++ b/modules/celtuce-core/src/celtuce/impl/server.clj
@@ -193,10 +193,12 @@
   ListCommands
   (blpop [this ^long sec ks]
     (let [res (.blpop this sec ^objects (into-array Object ks))]
-      [(.key res) (.value res)]))
+      (when res
+        [(.key res) (.value res)])))
   (brpop [this ^long sec ks]
     (let [res (.brpop this sec ^objects (into-array Object ks))]
-      [(.key res) (.value res)]))
+      (when res
+        [(.key res) (.value res)])))
   (brpoplpush [this ^long sec s d]
     (.brpoplpush this sec s d))
   (lindex [this k ^long idx]

--- a/modules/celtuce-manifold/src/celtuce/manifold/cluster.clj
+++ b/modules/celtuce-manifold/src/celtuce/manifold/cluster.clj
@@ -201,10 +201,10 @@
   ListCommands
   (blpop [this ^long sec ks]
     (d/chain (d/->deferred (.blpop this sec ^objects (into-array Object ks)))
-             (fn [^KeyValue res] [(.key res) (.value res)])))
+             (fn [^KeyValue res] (when res [(.key res) (.value res)]))))
   (brpop [this ^long sec ks]
     (d/chain (d/->deferred (.brpop this sec ^objects (into-array Object ks)))
-             (fn [^KeyValue res] [(.key res) (.value res)])))
+             (fn [^KeyValue res] (when res [(.key res) (.value res)]))))
   (brpoplpush [this ^long sec s d]
     (d/->deferred (.brpoplpush this sec s d)))
   (lindex [this k ^long idx]

--- a/modules/celtuce-manifold/src/celtuce/manifold/server.clj
+++ b/modules/celtuce-manifold/src/celtuce/manifold/server.clj
@@ -201,10 +201,10 @@
   ListCommands
   (blpop [this ^long sec ks]
     (d/chain (d/->deferred (.blpop this sec ^objects (into-array Object ks)))
-             (fn [^KeyValue res] [(.key res) (.value res)])))
+             (fn [^KeyValue res] (when res [(.key res) (.value res)]))))
   (brpop [this ^long sec ks]
     (d/chain (d/->deferred (.brpop this sec ^objects (into-array Object ks)))
-             (fn [^KeyValue res] [(.key res) (.value res)])))
+             (fn [^KeyValue res] (when res [(.key res) (.value res)]))))
   (brpoplpush [this ^long sec s d]
     (d/->deferred (.brpoplpush this sec s d)))
   (lindex [this k ^long idx]

--- a/test/celtuce/cluster_manifold_test.clj
+++ b/test/celtuce/cluster_manifold_test.clj
@@ -214,7 +214,13 @@
   (testing "list blocking commands"
     @(redis/mrpush *cmds* "bl" [1 2 3])
     (is (= ["bl" 1] @(redis/blpop *cmds* 1 ["bl"])))
-    (is (= ["bl" 3] @(redis/brpop *cmds* 1 ["bl"])))))
+    (is (= ["bl" 3] @(redis/brpop *cmds* 1 ["bl"])))
+
+    @(redis/del *cmds* "bl")
+    (is (nil? @(redis/blpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")
+    (is (nil? @(redis/brpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")))
 
 (deftest set-commands-test
 

--- a/test/celtuce/cluster_sync_test.clj
+++ b/test/celtuce/cluster_sync_test.clj
@@ -216,7 +216,13 @@
   (testing "list blocking commands"
     (redis/mrpush *cmds* "bl" [1 2 3])
     (is (= ["bl" 1] (redis/blpop *cmds* 1 ["bl"])))
-    (is (= ["bl" 3] (redis/brpop *cmds* 1 ["bl"])))))
+    (is (= ["bl" 3] (redis/brpop *cmds* 1 ["bl"])))
+
+    (redis/del *cmds* "bl")
+    (is (nil? (redis/blpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")
+    (is (nil? (redis/brpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")))
 
 (deftest set-commands-test
 

--- a/test/celtuce/server_manifold_test.clj
+++ b/test/celtuce/server_manifold_test.clj
@@ -215,7 +215,13 @@
   (testing "list blocking commands"
     @(redis/mrpush *cmds* "bl" [1 2 3])
     (is (= ["bl" 1] @(redis/blpop *cmds* 1 ["bl"])))
-    (is (= ["bl" 3] @(redis/brpop *cmds* 1 ["bl"])))))
+    (is (= ["bl" 3] @(redis/brpop *cmds* 1 ["bl"])))
+
+    @(redis/del *cmds* "bl")
+    (is (nil? @(redis/blpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")
+    (is (nil? @(redis/brpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")))
 
 (deftest set-commands-test
 

--- a/test/celtuce/server_sync_test.clj
+++ b/test/celtuce/server_sync_test.clj
@@ -217,7 +217,13 @@
   (testing "list blocking commands"
     (redis/mrpush *cmds* "bl" [1 2 3])
     (is (= ["bl" 1] (redis/blpop *cmds* 1 ["bl"])))
-    (is (= ["bl" 3] (redis/brpop *cmds* 1 ["bl"])))))
+    (is (= ["bl" 3] (redis/brpop *cmds* 1 ["bl"])))
+
+    (redis/del *cmds* "bl")
+    (is (nil? (redis/blpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")
+    (is (nil? (redis/brpop *cmds* 1 ["bl"]))
+        "pop on empty list should return nil, not throw NPE")))
 
 (deftest set-commands-test
 


### PR DESCRIPTION
When `brprop` and `blpop` complete before a value could be popped, lettuce returns a null, which causes a NullPointerException in celtuce.  This patch fixes the methods to return nil instead.

I don't have a cluster running and I'm not immediately sure how to start one, but I did update the tests and hopefully it's easy for you to run them. The server tests pass.