### PR TITLE
Add TransactionalCommands implementation to cluster

### DIFF
--- a/modules/celtuce-core/src/celtuce/impl/cluster.clj
+++ b/modules/celtuce-core/src/celtuce/impl/cluster.clj
@@ -569,5 +569,19 @@
                 (if-not c nil {:x (.x c) :y (.y c)})))
          (into [])))
   (geodist [this key from to unit]
-    (.geodist this key from to (->unit unit))))
+    (.geodist this key from to (->unit unit)))
+
+  TransactionalCommands
+  (discard [this]
+    (.discard this))
+  (exec [this]
+    (into [] (.exec this)))
+  (multi [this]
+    (.multi this))
+  (watch [this key]
+    (.watch this ^objects (into-array Object [key])))
+  (mwatch [this keys]
+    (.watch this ^objects (into-array Object keys)))
+  (unwatch [this]
+    (.unwatch this)))
 


### PR DESCRIPTION
I was getting error using `multi` command from cluster-client.
This patch fixes this issue.