### PR TITLE
allow pool configuration based on raw GenericObjectPoolConfig as an a…

### DIFF
--- a/.deps-versions.clj
+++ b/.deps-versions.clj
@@ -1,2 +1,2 @@
-(def celtuce-version "0.3.4")
+(def celtuce-version "0.3.5-config-pool")
 (def clj-version "1.10.1")

--- a/modules/celtuce-pool/src/celtuce/pool.clj
+++ b/modules/celtuce-pool/src/celtuce/pool.clj
@@ -38,7 +38,9 @@
 
 (defn conn-pool
   "Create a ConnectionPoolImpl that wraps a ConnectionPoolSupport.
-  Takes a connector and a command function that will be called on pooled connections"
+  Takes a connector and a command function that will be called on pooled connections.
+  Last parameter (options) allows to fully customize your pool based on Apache2 GenericObjectPoolConfig;
+  you have two options: pass a map with keys max-idle, min-idle and max-total or a org.apache.commons.pool2.impl.GenericObjectPoolConfig"
   ([connector cmds-fn]
    (conn-pool connector cmds-fn {}))
   ([{:keys [redis-client stateful-conn codec] :as connector} cmds-fn options]
@@ -57,7 +59,9 @@
              (.connectPubSub ^RedisClusterClient redis-client codec)
              RedisClient
              (.connectPubSub ^RedisClient redis-client ^RedisCodec codec)))))
-     (pool-config options))
+     (if (map? options)
+       (pool-config options)
+       options))
     connector
     cmds-fn)))
 


### PR DESCRIPTION
### What
I propose the change to function conn-pool in order to allow passing as last parameter `options` also a raw object `org.apache.commons.pool2.impl.GenericObjectPoolConfig` , in the same time maintaining the alternative to pass also a plain clojure map (as previous versions)

### Why
I want to be able to perform specific, low level configurations of my pools.

### Example
I wanted in my project to monitor via JMX the pools and I wanted to be able to give specific values to `jmxBaseName` and `jmxNamePrefix`; this was impossible without the change (or, at least, I did not find a different way to do it)