### PR TITLE
Script-flush call needs @ in front of it now

### DIFF
--- a/test/celtuce/cluster_manifold_test.clj
+++ b/test/celtuce/cluster_manifold_test.clj
@@ -314,7 +314,7 @@
         (is (= 10  @(redis/eval    *cmds* script :integer [])))
         (is (= sha (redis/digest  *cmds* script)))
         (is (= 10  @(redis/evalsha *cmds* sha :integer [])))
-        (redis/script-flush *cmds*)
+        @(redis/script-flush *cmds*)
         (is (thrown? io.lettuce.core.RedisCommandExecutionException
                      @(redis/evalsha *cmds* sha :integer [])))))))
 


### PR DESCRIPTION
After adding this:

```
> java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.282-b08, mixed mode)
```

```
 ~/celtuce | fix-script-test
> lein clean ; lein compile ; lein test

lein test celtuce.cluster-dynamic-test

lein test celtuce.cluster-manifold-test

lein test celtuce.cluster-sync-test

lein test celtuce.connector-test

lein test celtuce.pool-test

lein test celtuce.server-dynamic-test

lein test celtuce.server-manifold-test

lein test celtuce.server-sync-test

Ran 50 tests containing 719 assertions.
0 failures, 0 errors.
```