### PR TITLE
Accept RedisURI instead of just a string

### DIFF
--- a/modules/celtuce-core/project.clj
+++ b/modules/celtuce-core/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure ~clj-version]
-                 [io.lettuce/lettuce-core "6.1.1.RELEASE"]
+                 [io.lettuce/lettuce-core "6.1.4.RELEASE"]
                  [potemkin "0.4.5"]
                  [com.taoensso/nippy "3.1.1"]
                  [com.twitter/carbonite "1.5.0"]]

--- a/modules/celtuce-pool/project.clj
+++ b/modules/celtuce-pool/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure ~clj-version]
                  [celtuce-core ~celtuce-version]
-                 [org.apache.commons/commons-pool2 "2.9.0"]]
+                 [org.apache.commons/commons-pool2 "2.10.0"]]
   :global-vars {*warn-on-reflection* true})


### PR DESCRIPTION
We want to be able to supply a RedisURI object instead of just a string as it works a little bit better for us and how we construct those objects. I'll post this here too if it helps anyone who wants to build a RedisURI from a clj map:

```clojure
(defn ^RedisURI build-redis-uri
  [{:keys [uri

           host
           port
           username
           password
           ssl?
           verify-peer?
           start-tls?
           database
           client-name
           timeout-ms]}]
  (if uri
    (RedisURI/create ^String uri)
    (let [^RedisURI$Builder builder (RedisURI/builder)]
      (.withHost builder host)
      (when port
        (.withPort builder port))
      (when (and (not username) password)
        (.withPassword builder (.toCharArray ^String password)))
      (when (and username password)
        (.withAuthentication builder ^String username (.toCharArray ^String password)))
      (when (boolean? ssl?)
        (.withSsl builder ^boolean ssl?))
      (when (boolean? verify-peer?)
        (.withVerifyPeer builder ^boolean verify-peer?))
      (when (boolean? start-tls?)
        (.withStartTls builder start-tls?))
      (when database
        (.withDatabase builder database))
      (when client-name
        (.withClientName builder client-name))
      (when timeout-ms
        (.withTimeout builder (Duration/ofMillis timeout-ms)))
      (.build builder))))
```